### PR TITLE
Fix stylesheet link tag in base.html

### DIFF
--- a/newschool/templates/base.html
+++ b/newschool/templates/base.html
@@ -4,7 +4,7 @@
 <html lang="en">
     <head>
         <title>{% block title %}New School Project{% endblock %}</title>
-        <link href="{% static 'css/bootstrap.min.css' %}">
+        <link rel="stylesheet" type="text/css" href="{% static 'css/bootstrap.min.css' %}" />
     </head>
 
     <body>


### PR DESCRIPTION
Stylesheet link missing rel and type attributes....will not render styles w/o them
